### PR TITLE
Update to CCCL 2.1.0.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,5 @@
 {% set name = "cccl" %}
-{% set version = "2.0.1" %}
-{% set thrust_version = "2.0.1" %}
-{% set cub_version = "2.0.1" %}
-{% set libcudacxx_version = "1.9.0" %}
-{% set platform = "linux-x86_64" %}  # [linux64]
-{% set platform = "linux-ppc64le" %}  # [ppc64le]
-{% set platform = "linux-sbsa" %}  # [aarch64]
-{% set platform = "windows-x86_64" %}  # [win]
+{% set version = "2.1.0" %}
 {% set extension = "tar.gz" %}  # [not win]
 {% set extension = "zip" %}  # [win]
 
@@ -20,18 +13,18 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/NVIDIA/thrust/archive/refs/tags/{{ thrust_version }}.{{ extension }}
+  - url: https://github.com/NVIDIA/thrust/archive/refs/tags/{{ version }}.{{ extension }}
     folder: thrust
-    sha256: 06df373cf487cf3710be6798bc5441a03685b78e5c1338e2f14005f7ccd030e6  # [linux]
-    sha256: 39a9fc88b0b06da118cc3ed28cbfca27b2a7ae192877996cab1295176ceed65e  # [win]
-  - url: https://github.com/NVIDIA/cub/archive/refs/tags/{{ cub_version }}.{{ extension }}
+    sha256: ebfa1a31867a95b8b0555ae45fc7c45538edfa5929ec718951eae0bbc7ed3108  # [linux]
+    sha256: 00d0db34bac00c3b079654a997443952ae724142b464c427207b60d853522f1d  # [win]
+  - url: https://github.com/NVIDIA/cub/archive/refs/tags/{{ version }}.{{ extension }}
     folder: cub
-    sha256: beeef0962c87eca994db06cb9e9168a71c63fb369398a5b5f1db923140814701  # [linux]
-    sha256: 22308facf62421d6dd2489b9554ffa4908dca13d3921a3e7f2965c5a6984cd20  # [win]
-  - url: https://github.com/NVIDIA/libcudacxx/archive/refs/tags/{{ libcudacxx_version }}.{{ extension }}
+    sha256: 60f7633c81c8c0e970bcf59fa6d19a0ed136524dbbcd52b94ea42721dde8cd6b  # [linux]
+    sha256: 8ec47307f5e99379ac1cf6722cd5a24fc15b84b0f5361bebd453645a5e4bb34d  # [win]
+  - url: https://github.com/NVIDIA/libcudacxx/archive/refs/tags/{{ version }}.{{ extension }}
     folder: libcudacxx
-    sha256: 05b1435ad65f5bdef1bb8d1eb29dc8f0f7df34c01d77bf8686687a4603588bce  # [linux]
-    sha256: d7864460ce8def8e0620cb9dd891e94299ade75eac75aa96b34001af3cdb074c  # [win]
+    sha256: 0c140aedd4fbc22e0432badb2a195274c8800f8d8d7d4bc917ea3f8a9810f6ce  # [linux]
+    sha256: f1fb36ac676aabbfd48ba94c5bd038f118f3af4b1bf49063c9c8812bbd30c9eb  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR updates all CCCL packages (thrust, cub, libcudacxx) to version 2.1.0. This is the final release before the packages were moved to a monorepo hosted at https://github.com/NVIDIA/cccl. The next release is 2.2.0 and will require this recipe to be updated for the new monorepo source.